### PR TITLE
Correct image detail save redirect

### DIFF
--- a/app/(protected)/app/foods/add/page.tsx
+++ b/app/(protected)/app/foods/add/page.tsx
@@ -26,7 +26,7 @@ export default function AddFoodPage() {
     // Include image data if available
     const foodWithImage = imageData ? { ...food, image: imageData } : food;
     await dbAddFood(foodWithImage);
-    router.back();
+    router.push("/app");
   };
 
   const handleClose = () => {

--- a/app/(protected)/app/foods/edit/[id]/page.tsx
+++ b/app/(protected)/app/foods/edit/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function EditFoodPage({
   ) => {
     if (food) {
       await dbUpdateFood(food.id, updatedFood);
-      router.back();
+      router.push("/app");
     }
   };
 

--- a/app/(protected)/app/symptoms/add/page.tsx
+++ b/app/(protected)/app/symptoms/add/page.tsx
@@ -14,7 +14,7 @@ export default function AddSymptomPage() {
     symptom: Omit<Symptom, "id" | "timestamp">
   ) => {
     await dbAddSymptom(symptom);
-    router.back();
+    router.push("/app");
   };
 
   const handleClose = () => {

--- a/app/(protected)/app/symptoms/edit/[id]/page.tsx
+++ b/app/(protected)/app/symptoms/edit/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function EditSymptomPage({
   ) => {
     if (symptom) {
       await dbUpdateSymptom(symptom.id, updatedSymptom);
-      router.back();
+      router.push("/app");
     }
   };
 


### PR DESCRIPTION
Redirect users to `/app` after saving food/symptom entries to fix incorrect navigation to the home page.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents%3Fid=bc-ecbebd21-05c8-472d-88d2-aa0f25e6792b) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-ecbebd21-05c8-472d-88d2-aa0f25e6792b)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)